### PR TITLE
fix : Update Voucher Entry Doctype

### DIFF
--- a/voucher_utility/voucher_utility/doctype/voucher_account/voucher_account.json
+++ b/voucher_utility/voucher_utility/doctype/voucher_account/voucher_account.json
@@ -8,12 +8,12 @@
  "field_order": [
   "voucher_entry_type",
   "account",
-  "amount",
   "party_type",
   "party",
   "column_break_pgpw",
   "reference_doctype",
   "description",
+  "amount",
   "reference_docname",
   "attachments"
  ],
@@ -90,7 +90,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-18 11:40:04.774652",
+ "modified": "2024-09-21 14:45:57.817128",
  "modified_by": "Administrator",
  "module": "Voucher Utility",
  "name": "Voucher Account",

--- a/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.js
+++ b/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.js
@@ -115,7 +115,6 @@ frappe.ui.form.on('Voucher Account', {
                     company: frm.doc.company
                 },
                 callback: function(response) {
-                  console.log(response);
                     if (response.message) {
                         let default_account = response.message;
                         frappe.model.set_value(cdt, cdn, 'account', default_account);

--- a/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.js
+++ b/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.js
@@ -39,21 +39,39 @@ frappe.ui.form.on('Voucher Entry', {
 
 
     },
-    refresh: function(frm) {
-        frm.add_custom_button(__('View'), function(){
-          frappe.call({
-          method: "voucher_utility.voucher_utility.doctype.voucher_entry.voucher_entry.view_journal_entry",
-          args: {
-            'voucher_entry':frm.doc.name
-          },
-          callback: function(r) {
-            if (r.message){
-              frappe.set_route('Form','Journal Entry', r.message);
-              }
-            }
-          })
-       })
-    },
+  refresh: function(frm) {
+        // Automatically fetch the balance when an account is selected
+        if (frm.doc.docstatus === 1) {
+         frm.add_custom_button(__('View'), function(){
+           frappe.call({
+           method: "voucher_utility.voucher_utility.doctype.voucher_entry.voucher_entry.view_journal_entry",
+           args: {
+             'voucher_entry':frm.doc.name
+           },
+           callback: function(r) {
+             if (r.message){
+               frappe.set_route('Form','Journal Entry', r.message);
+               }
+             }
+           });
+        });
+     }
+   },
+   account: function(frm){
+     if (frm.doc.account) {
+         frappe.call({
+             method: 'erpnext.accounts.utils.get_balance_on',
+             args: {
+                 account: frm.doc.account,
+             },
+             callback: function(r) {
+                 if (r.message) {
+                     frm.set_value('balance', r.message); // Set the balance field in the form
+                 }
+             }
+         });
+     }
+   }
 
   });
 
@@ -97,6 +115,7 @@ frappe.ui.form.on('Voucher Account', {
                     company: frm.doc.company
                 },
                 callback: function(response) {
+                  console.log(response);
                     if (response.message) {
                         let default_account = response.message;
                         frappe.model.set_value(cdt, cdn, 'account', default_account);

--- a/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.json
+++ b/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.json
@@ -63,8 +63,10 @@
   {
    "fetch_from": ".enabled",
    "fieldname": "account",
-   "fieldtype": "Data",
-   "label": "Account"
+   "fieldtype": "Link",
+   "label": "Account",
+   "options": "Account",
+   "read_only": 1
   },
   {
    "fieldname": "total_amount",
@@ -135,8 +137,9 @@
   },
   {
    "fieldname": "cost_center",
-   "fieldtype": "Data",
-   "label": "Cost Center"
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
   },
   {
    "fieldname": "column_break_fj1v",
@@ -156,7 +159,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-18 11:33:08.842343",
+ "modified": "2024-09-24 10:39:52.617346",
  "modified_by": "Administrator",
  "module": "Voucher Utility",
  "name": "Voucher Entry",

--- a/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.json
+++ b/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.json
@@ -128,7 +128,8 @@
   {
    "fieldname": "balance",
    "fieldtype": "Float",
-   "label": "Balance"
+   "label": "Balance",
+   "read_only": 1
   },
   {
    "fieldname": "sb_accounting_dimensions",
@@ -159,7 +160,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-24 10:39:52.617346",
+ "modified": "2024-09-24 11:58:06.084284",
  "modified_by": "Administrator",
  "module": "Voucher Utility",
  "name": "Voucher Entry",

--- a/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.py
+++ b/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.py
@@ -1,7 +1,8 @@
 from frappe.model.document import Document
 import frappe
 from frappe.utils import get_link_to_form
-from frappe import _ 
+from erpnext.accounts.utils import get_account_balances
+from frappe import _
 
 class VoucherEntry(Document):
     def on_submit(self):
@@ -21,6 +22,7 @@ class VoucherEntry(Document):
         journal_entry.user_remark = self.user_remarks
         journal_entry.cheque_date = self.reference_date
         journal_entry.cheque_no = self.bank_reference
+        journal_entry.cost_center = self.cost_center
         journal_entry.voucher_type = "Journal Entry"
 
         if self.payment_type == 'Pay':
@@ -73,7 +75,7 @@ def get_default_account(voucher_entry_type, company):
     Returns:
         str: The default account associated with the Voucher Entry Type and company.
     """
-    default_account = frappe.db.get_value('Accounts',{'parent': voucher_entry_type, 'parenttype': 'Voucher Entry Type', 'company': company}, 'default_account')
+    default_account = frappe.db.get_value('Voucher Accounts',{'parent': voucher_entry_type, 'parenttype': 'Voucher Entry Type', 'company': company}, 'default_account')
     return default_account
 
 @frappe.whitelist()


### PR DESCRIPTION
## Feature description
-Update Voucher Entry Doctype

## Solution description
-Changed the field type of Account and set it to Read Only.
-Changed the field type of Cost Center.
-Displayed the view button ,after the form is submitted.
-Fetched Account balance from accounts.
-Fetched the account of voucher entry type in to the child table.
-Added a custom "Cost Center" field to the Journal Entry.
-When creating journal entry upon the approval of Voucher entry,the cost center is fetched from voucher entry.

## Output
![image](https://github.com/user-attachments/assets/cdee716c-9bd1-47d7-9833-52746be8197a)
![image](https://github.com/user-attachments/assets/8f042730-8e1a-4fc2-b914-b6e82d369253)
![image](https://github.com/user-attachments/assets/2810b2f2-279e-46c6-98c5-9d60410e3fd8)
![image](https://github.com/user-attachments/assets/65fe7d89-52cc-4e59-b90d-d89f1c4ab81a)
![image](https://github.com/user-attachments/assets/a1e89f65-0813-4d3d-aac1-c354ad75d615)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox