### PR TITLE
fix:Add validation for Mode of Payment and associated bank account in voucher entry

### DIFF
--- a/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.js
+++ b/voucher_utility/voucher_utility/doctype/voucher_entry/voucher_entry.js
@@ -71,6 +71,37 @@ frappe.ui.form.on('Voucher Entry', {
              }
          });
      }
+   },
+   mode_of_payment: function(frm) {
+       // Hide the account field initially
+       frm.set_df_property('account', 'hidden', true);
+       frm.refresh_field('account');
+
+       frappe.call({
+           method: "voucher_utility.voucher_utility.doctype.voucher_entry.voucher_entry.validate_mode_of_payment_with_bank_account",
+           args: {
+               voucher_entry: frm.doc.name,
+               mode_of_payment: frm.doc.mode_of_payment,
+               company: frm.doc.company
+           },
+           callback: function(r) {
+               if (r.exc) {
+                   frappe.msgprint(r.exc);
+                   return;
+               }
+
+               const { valid_accounts, has_company } = r.message || {};
+
+               // Show account field if company is associated
+               if (has_company) {
+                   frm.set_df_property('account', 'hidden', false);
+                   frm.refresh_field('account');
+
+                   // Set the first valid account or clear the field
+                   frm.set_value('account', valid_accounts.length ? valid_accounts[0] : '');
+               }
+           }
+       });
    }
 
   });


### PR DESCRIPTION
## Feature description
-Add validation for Mode of Payment with associated bank account

## Solution description
 -Added function `validate_mode_of_payment_with_bank_account` to check if the selected Mode of Payment has a valid bank        account linked for the specified company.
 -Raised a validation error if no bank account is associated.

## Output
![image](https://github.com/user-attachments/assets/1a7e70e9-f436-4850-9b73-5fd56aef628f)
![image](https://github.com/user-attachments/assets/bd1e12fc-75d7-4cc0-8653-e80741e84a50)

## Is there any existing behavior change of other features due to this code change?
-yes.

## Was this feature tested on the browsers?
  - Mozilla Firefox